### PR TITLE
Update "Migrations to GitHub Enterprise (GitHub Enterprise Cloud to GitHub Enterprise Cloud EMU)" page with correct repo size limit

### DIFF
--- a/_offerings/offering-migrations-emu.md
+++ b/_offerings/offering-migrations-emu.md
@@ -35,7 +35,7 @@ In this engagement, a GitHub Professional Services Engineer will guide you throu
 - Setup the Tooling in Customers Environment
 - GitHub migration tooling will be available POST engagement
 - Completion of dry-run migrations to 1 GHEC Organisation including assistance in the creation of Mapping File
-  - Up to 5 repos with the size of 1 gigabyte or less
+  - Up to 5 repos with the size of 10 gigabytes or less
 - Outline migration process and steps that customers would follow post-GitHub engagement
 - Eight (8) hours of Post-Engagement support on Tooling and Migration Questions via EMU Migrations GitHub Repo. Support provided for 30 days post engagement only. Issues will be addressed on a first come first serve basis.
 - The tooling utilised during the migration is specifically for the GHEC to GEHC+EMU migration and is not supported outside of this engagement.
@@ -54,4 +54,4 @@ After this engagement, your team will be able to:
 - An SSH client
 - Ensure every employee has a GitHub Enterprise Cloud EMU account
 - A mapping of legacy GitHub Enterprise Cloud accounts to GitHub Enterprise Cloud EMU account
-- Maximum repository size limit not greater than 2GB
+- Maximum repository size limit not greater than 10GB


### PR DESCRIPTION
I spotted that the "Migrations to GitHub Enterprise (GitHub Enterprise Cloud to GitHub Enterprise Cloud EMU)" page in the Service Catalog mentions maximum sizes for repos that can be migrated - in one place, it mentions 2GB, and in another 1GB.

Making the assumption that we use GitHub Enterprise Importer for these migrations - which I believe is the case - and there isn't some other reason to state a lower figure, this corrects those figures to reflect GEI's 10GB per repo limit.