### PR TITLE
Add CodeQL offerings

### DIFF
--- a/_offerings/offering-codeql-query-customizations.md
+++ b/_offerings/offering-codeql-query-customizations.md
@@ -34,19 +34,16 @@ N/A
 
 ### Syllabus
 
-This offering will include:
-
-1. A pre-sales scoping session to define each customization to be implemented and determine an estimated time-to-implement for each customization based on its assigned difficulty. To do the estimate we require that the following be supplied:
-  - the security vulnerability/code pattern/false positive result that they want to find/omit with CodeQL
-  - the list of sources/sinks/sanitizers to be modelled
-  - the test setup (code examples) to validate that the customization improves analysis as expected
+1. A pre-sales scoping session to define each customization to be implemented and determine an estimated time-to-implement for each customization based on its assigned difficulty. To do the estimate we require one or more of the following be supplied:
+   - A security vulnerability/code pattern/false positive result that they want to find/omit with CodeQL
+   - A list of sources/sinks/sanitizers to be modelled
+   - A test setup (code examples) to validate that the customization improves analysis as expected
 2. A post-sales kick-off session to clarify scope and remediate any missing dependencies, such as access to proprietary code
-3. The main asynchronous development cycle
-  - Write CodeQL sources/sinks/sanitizers
-  - Delivery of a customization as a custom bundle and provide deployment instructions
-  - Min one for simple, max two for complex - iterations of review + refinement:  
-    - Review feedback on customization impact (reduced false positives/negatives) via issues and a project board
-    - Refine sources/sinks/sanitizers if impact is not as expected
+3. Development of the customizations, using an iterative process:
+   - Write CodeQL sources/sinks/sanitizers
+   - Deliver the customizations with deployment instructions
+   - Review feedback on customization impact (reduced false positives/negatives) via issues and a project board
+   - Refine sources/sinks/sanitizers if impact is not as expected
 4. A final review and Q&A session
 
 ### Learning outcomes/business outcomes

--- a/_offerings/offering-codeql-query-customizations.md
+++ b/_offerings/offering-codeql-query-customizations.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: CodeQL Query Customizations
+description: Commision GitHub to customize the existing CodeQL queries to provide better results for your organization.
+parameterized_name: codeql-query-customizations
+---
+
+### Overview
+
+CodeQL ships with hundreds of queries out of the box for each language and includes comprehensive support for finding vulnerabilities in code using the most common and popular libraries and frameworks. However, if you use libraries that are internal to your organization, less popular libraries which are not covered by default, or use uncommon code patterns, you may find CodeQL misses results (false negatives) or produces incorrect results (false positives).
+
+In this engagement we will collaborate with you to extend or modify the existing queries to reduce false positives or false negatives.
+
+You will be able to specify some number of (potentially internal) extension items (sources/sinks/sanitizers), and have a CodeQL expert deliver models that will allow pre-existing CodeQL queries to return customized results. Options for extension items are grouped within different languages supported by CodeQL (Java, JavaScript/TypeScript, Go, C#, Python, C/C++, Ruby). For each requested customization, example code will be provided, or, for non-internal extensions, open source vulnerabilities or false positive examples that you wish to target.
+
+### Offering level
+
+N/A
+
+### Target Audience
+
+- Product/Application Security team
+- Security architecture team
+- Development/Engineering/QA testing team
+- SecDevOps sponsor
+- CTO or designated representative
+- CISO or designated representative
+
+### Key features and benefits
+
+- Main deliverable of custom models for extension items and custom CodeQL bundle containing custom models.
+- Example CodeQL classes and predicates for future CodeQL learning efforts.
+- Example custom CodeQL bundle mechanism.
+
+### Syllabus
+
+This offering will include:
+
+1. A pre-sales scoping session to define each customization to be implemented and determine an estimated time-to-implement for each customization based on its assigned difficulty. To do the estimate we require that the following be supplied:
+  - the security vulnerability/code pattern/false positive result that they want to find/omit with CodeQL
+  - the list of sources/sinks/sanitizers to be modelled
+  - the test setup (code examples) to validate that the customization improves analysis as expected
+2. A post-sales kick-off session to clarify scope and remediate any missing dependencies, such as access to proprietary code
+3. The main asynchronous development cycle
+  - Write CodeQL sources/sinks/sanitizers
+  - Delivery of a customization as a custom bundle and provide deployment instructions
+  - Min one for simple, max two for complex - iterations of review + refinement:  
+    - Review feedback on customization impact (reduced false positives/negatives) via issues and a project board
+    - Refine sources/sinks/sanitizers if impact is not as expected
+4. A final review and Q&A session
+
+### Learning outcomes/business outcomes
+
+- sources/sinks/sanitizers that allow pre-existing queries to detect the example vulnerabilities or omit the example false positives
+- Participants will be able to apply the delivered bundle to generate improved results
+
+### Prerequisites
+
+- A list of sources/sinks/sanitizers has been gathered that you wish to have modelled. In the case where an entire API is requested there must be some set of scope - in terms of - sources/sinks/sanitizers that define sufficiently implemented
+- Example code has been gathered where CodeQL analysis (either via CLI or in Actions) has run as a baseline for the results to be improved
+- A CodeQL Analysis Engineer has evaluated the feasibility of the proposed technical scope of the customization to be developed as well as CodeQL support for the language(s) to be targeted. Customizations can only be developed to model problems of a clear and reasonably defined scope.

--- a/_offerings/offering-codeql-query-development.md
+++ b/_offerings/offering-codeql-query-development.md
@@ -25,14 +25,12 @@ After an initial scoping and feasibility assessment meeting, one or more CodeQL 
 
 ### Syllabus
 
-This engagement will consist of the following stages:
-
 1. A pre-sales scoping and feasibility evaluation meeting to define each rule to be implemented as a query and determine an estimated time-to-implement for each rule based on its assigned difficulty.
 2. A post-sales kick-off call to clarify any remaining scope or architectural questions as well as  to remediate any missing dependencies, such as access to proprietary code or query test cases.
 3. Internal project management and engineering tasks.
-4. The primary development cycle
+4. Development of the queries, using an iterative process:
    - CodeQL query development
-   - Incremental delivery of queries as CodeQL query packs with deployment guidance
+   - Incremental delivery of queries as CodeQL query packs or similar with deployment guidance
    - Collaborative review of query feedback and issue reports
    - Remediation of any false-positives, false-negatives, or other issues reported
    - Optionally, based on the individual services agreement, open-sourcing of the queries

--- a/_offerings/offering-codeql-query-development.md
+++ b/_offerings/offering-codeql-query-development.md
@@ -1,0 +1,52 @@
+---
+layout: page
+title: CodeQL Query Development
+description: Commision GitHub to develop CodeQL queries based on your unique business needs.
+parameterized_name: codeql-query-development
+---
+
+### Overview
+
+CodeQL ships with hundreds of queries out of the box for each language that typically cover the most critical and important security vulnerability categories. In this engagement, we will write, deliver and assist with testing and deploying one or more new queries to find security vulnerabilities which are not covered out-of-the-box, or to identify correctness, performance or code smell issues.
+
+For each requested query, detailed specifications for the queries to be developed must be provided. If determined to be necessary during the pre-sales scoping phase, test-cases and example code to assist development and verify the correctness of deliverable queries must also be provided.
+
+This engagement also offers the option to additionally release the developed CodeQL queries as an open-source contribution to the CodeQL Standard Library, thus saving future query maintenance costs at the expense of a longer initial query development phase.
+
+### Target Audience
+
+- Security Researchers
+- Application Security Teams
+- Software Engineering Technical Leads
+
+### Key Features and Benefits
+
+After an initial scoping and feasibility assessment meeting, one or more CodeQL experts will be assigned to write custom queries and assist in deploying them in an organization. This engagement will provide CodeQL queries adding targeted code coverage of additional or organization-specific vulnerabilities, correctness, performance, or code smell issues.
+
+### Syllabus
+
+This engagement will consist of the following stages:
+
+1. A pre-sales scoping and feasibility evaluation meeting to define each rule to be implemented as a query and determine an estimated time-to-implement for each rule based on its assigned difficulty.
+2. A post-sales kick-off call to clarify any remaining scope or architectural questions as well as  to remediate any missing dependencies, such as access to proprietary code or query test cases.
+3. Internal project management and engineering tasks.
+4. The primary development cycle
+   - CodeQL query development
+   - Incremental delivery of queries as CodeQL query packs with deployment guidance
+   - Collaborative review of query feedback and issue reports
+   - Remediation of any false-positives, false-negatives, or other issues reported
+   - Optionally, based on the individual services agreement, open-sourcing of the queries
+5. A final review and Q&A session
+
+### Learning/Business Outcomes
+
+- One or more custom queries ready to be deployed in your organization.
+- A deeper understanding of how CodeQL can be used to model patterns in your code.
+
+### Prerequisites
+
+- A clear technical scope for the CodeQL query or queries to be implemented can be provided; this prerequisite can be fulfilled through items including but not strictly limited to the following:
+  - Specifying an established coding standard which contains technical specifications for the behaviour to be enforced or prohibited as well as demonstrative examples of the behaviour in question
+  - An example of a security vulnerability, correctness issue, or otherwise undesired code pattern in a shareable codebase, proof-of-concept application, or code snippet
+- To develop custom queries which specifically model proprietary or closed-source software, it must be possible to provide access to the source code to be targeted or self-contained examples modelling their proprietary code.
+- In the pre-sales phase, a CodeQL Analysis Engineer has evaluated the feasibility of the proposed technical scope of the custom queries to be developed as well as CodeQL support for the language(s) to be targeted. Custom queries can only be developed to model problems of a clear and reasonably defined scope.

--- a/_offerings/offering-codeql-query-writing-tailored-workshop.md
+++ b/_offerings/offering-codeql-query-writing-tailored-workshop.md
@@ -37,25 +37,23 @@ organization and technical challenges.
 
 ### Key Features and Benefits
 
- * A guided interactive training with a CodeQL expert to gain a deeper understanding of CodeQL.
- * Focused on a query writing topic of your choice.
- * Learn reusable patterns for query development for similar problems.
- * Receive example CodeQL databases, queries and learning material for continuing your learning after the session.
+- A guided interactive training with a CodeQL expert to gain a deeper understanding of CodeQL.
+- Focused on a query writing topic of your choice.
+- Learn reusable patterns for query development for similar problems.
+- Receive example CodeQL databases, queries and learning material for continuing your learning after the session.
 
 ### Syllabus
 
-This engagement will consist of the following stages:
-
- 1. A kick-off and discovery call to identify and refine the topic of the workshop. Please bring any supporting material with you (samples, references, relevant codebases etc.).
- 2. Creation of the Workshop by the CodeQL Analysis Engineer.
- 3. Delivery of the workshop in a single 2 hour block of time.
+ 1. A kick-off and discovery call to identify and refine the topic of the workshop. Please bring any supporting material with you - e.g. samples, references or relevant codebases.
+ 2. Development of the workshop based on the agreed topic and scope. This will typically require 1-2 weeks.
+ 3. Delivery of the workshop in a single 2 hour interactive remote session. All materials will be shared with you after the session.
 
 ### Learning/Business Outcomes
 
-* Enhanced understanding of CodeQL topics covered by the tailored training workshop.
-* Participants will be able to apply the patterns and approaches covered in the session to similar problems.
- * One or more queries identifying the example vulnerabilities or patterns to help accelerate your own query development for similar patterns.
+- Enhanced understanding of CodeQL topics covered by the tailored training workshop.
+- Participants will be able to apply the patterns and approaches covered in the session to similar problems.
+- One or more queries identifying the example vulnerabilities or patterns to help accelerate your own query development for similar patterns.
   
 ### Prerequisites
 
- * An identified CodeQL query writing topic. Workshops are typically structured around an example of a security vulnerability or code pattern you wish to find using CodeQL.
+- An identified CodeQL query writing topic. Workshops are typically structured around an example of a security vulnerability or code pattern you wish to find using CodeQL.

--- a/_offerings/offering-codeql-query-writing-tailored-workshop.md
+++ b/_offerings/offering-codeql-query-writing-tailored-workshop.md
@@ -1,0 +1,61 @@
+---
+layout: page
+title: CodeQL Query Writing Tailored Workshop
+description: This engagement creates a tailored 2 hour training course for using CodeQL to find a security vulnerbility or pattern of your choice.
+parameterized_name: codeql-query-writing-tailored-workshop
+---
+
+### Overview
+
+One of the most compelling aspects of CodeQL is its extensibility. Rather than
+being limited to a set of out of the box functions, new functionality can be
+added by authoring new queries using a powerful and comprehensive programming
+language called QL. Having the ability to author new CodeQL queries has a number
+of advantages such as being able to find new security vulnerabilities and being
+able to model new frameworks and codebases to provide higher-fidelity
+query results.
+
+An important aspect of being successful with CodeQL is an ability to design and
+write new CodeQL queries that solve new problems not addressed by the out of the
+box queries provided with CodeQL. In addition to our CodeQL
+Query Writing Training, which offers a fixed set of courses the you can select
+from, this offering provides you with a way to request and participate in
+workshops tailored to the unique business and technical challenges of your
+organization.
+
+In this offering, you will discuss your goals with a CodeQL Analysis Engineer
+who will in turn compose a workshop tailored to your goals and requirements. The
+workshop will be delivered in the same 2 hour format as the CodeQL Query Writing
+Trainings but designed to address the needs that are tailored do your
+organization and technical challenges.  
+
+### Target Audience
+
+- Security Researchers
+- Application Security Teams
+- Software Engineering Technical Leads
+
+### Key Features and Benefits
+
+ * A guided interactive training with a CodeQL expert to gain a deeper understanding of CodeQL.
+ * Focused on a query writing topic of your choice.
+ * Learn reusable patterns for query development for similar problems.
+ * Receive example CodeQL databases, queries and learning material for continuing your learning after the session.
+
+### Syllabus
+
+This engagement will consist of the following stages:
+
+ 1. A kick-off and discovery call to identify and refine the topic of the workshop. Please bring any supporting material with you (samples, references, relevant codebases etc.).
+ 2. Creation of the Workshop by the CodeQL Analysis Engineer.
+ 3. Delivery of the workshop in a single 2 hour block of time.
+
+### Learning/Business Outcomes
+
+* Enhanced understanding of CodeQL topics covered by the tailored training workshop.
+* Participants will be able to apply the patterns and approaches covered in the session to similar problems.
+ * One or more queries identifying the example vulnerabilities or patterns to help accelerate your own query development for similar patterns.
+  
+### Prerequisites
+
+ * An identified CodeQL query writing topic. Workshops are typically structured around an example of a security vulnerability or code pattern you wish to find using CodeQL.

--- a/_offerings/offering-codeql-query-writing-training.md
+++ b/_offerings/offering-codeql-query-writing-training.md
@@ -37,10 +37,10 @@ intermediate, and advanced courses in the following areas:
 
 ### Key Features and Benefits
 
- * A guided interactive training with a CodeQL expert to gain a deeper understanding of CodeQL.
- * Gain proficiency in the topics covered.
- * Learn reusable patterns for query development for similar problems.
- * Receive example CodeQL databases, queries and learning material for continuing your learning after the session.
+- A guided interactive training with a CodeQL expert to gain a deeper understanding of CodeQL.
+- Gain proficiency in the topics covered.
+- Learn reusable patterns for query development for similar problems.
+- Receive example CodeQL databases, queries and learning material for continuing your learning after the session.
 
 ### Syllabus
 
@@ -48,10 +48,10 @@ Each course will be delivered as a 2 hour interactive remote session. An engagem
 
 ### Learning/Business Outcomes
 
- * Enhanced understanding of CodeQL topics covered by the selected training modules.
- * Participants will be able to apply the patterns and approaches covered in the session to similar problems.
+- Enhanced understanding of CodeQL topics covered by the selected training modules.
+- Participants will be able to apply the patterns and approaches covered in the session to similar problems.
   
 ### Prerequisites
 
- * A CodeQL Analysis Engineer has discussed your training goals and has ensured that the courses are available for the topics you want to learn about.
- * A CodeQL Analysis Engineer has made a recommendation for a learning path.
+- A CodeQL Analysis Engineer has discussed your training goals and has ensured that the courses are available for the topics you want to learn about.
+- A CodeQL Analysis Engineer has made a recommendation for a learning path.

--- a/_offerings/offering-codeql-query-writing-training.md
+++ b/_offerings/offering-codeql-query-writing-training.md
@@ -1,0 +1,57 @@
+---
+layout: page
+title: CodeQL Query Writing Training
+description: Learn how to write CodeQL to find new security vulnerabilities or customize the existing rules through our extensive catalog of 2 hour training courses.
+parameterized_name: codeql-query-writing-training
+---
+
+### Overview
+
+One of the most compelling aspects of CodeQL is its extensibility. Rather than
+being limited to a set of out of the box functions, new functionality can be
+added by authoring new queries using a powerful and comprehensive programming
+language called QL. Having the ability to author new CodeQL queries has a number
+of advantages such as being able to find new security vulnerabilities and being
+able to model new frameworks and codebases to provide higher-fidelity query
+results.
+
+To support effective use of CodeQL, this engagement offers a systematic approach
+to learning CodeQL through the use of a structured set of 2 hour courses on
+topics relevant to new and experienced CodeQL authors. It offers introductory,
+intermediate, and advanced courses in the following areas:
+
+- **QL Core** - Which teaches the QL language fundamentals
+- **Language Dependent Features** - Which teaches the specific details of using
+  CodeQL (and the standard library) for a given programming language.
+- **CodeQL Tooling, Infrastructure, and Practice** - Which covers a variety of
+  topics in using the non-query related aspects of CodeQL in deployment and
+  command line scenarios.
+- **CodeQL Explorations and Projects** - Which covers advanced topics in CodeQL
+  as well as custom designed projects such as capture the flag exercises.
+
+### Target Audience
+
+- Security Researchers
+- Application Security Teams
+- Software Engineering Technical Leads
+
+### Key Features and Benefits
+
+ * A guided interactive training with a CodeQL expert to gain a deeper understanding of CodeQL.
+ * Gain proficiency in the topics covered.
+ * Learn reusable patterns for query development for similar problems.
+ * Receive example CodeQL databases, queries and learning material for continuing your learning after the session.
+
+### Syllabus
+
+Each course will be delivered as a 2 hour interactive remote session. An engagement will typically consist of multiple courses delivered as part of a "learning path" tailored towards your goals.
+
+### Learning/Business Outcomes
+
+ * Enhanced understanding of CodeQL topics covered by the selected training modules.
+ * Participants will be able to apply the patterns and approaches covered in the session to similar problems.
+  
+### Prerequisites
+
+ * A CodeQL Analysis Engineer has discussed your training goals and has ensured that the courses are available for the topics you want to learn about.
+ * A CodeQL Analysis Engineer has made a recommendation for a learning path.


### PR DESCRIPTION
This adds four CodeQL offerings to the site feed:
 * CodeQL Query Writing Training
 * CodeQL Query Writing Tailored Workshop
 * CodeQL Query Development
 * CodeQL Query Customizations

There is one further CodeQL offering which is "launched", but I don't want to be public - which is the "CodeQL Query Writing Training (Dev)" offering. This primarily exists to help defray the costs of the initial development of a training course that is not yet in our catalog, and I consider it to be effectively a "sub-SKU" of the CodeQL Query Writing Training (and therefore doesn't need its own public datasheet).