### PR TITLE
Update offering-github-for-non-developers-training.md

### DIFF
--- a/_offerings/offering-github-for-non-developers-training.md
+++ b/_offerings/offering-github-for-non-developers-training.md
@@ -20,8 +20,6 @@ It's no secret that it takes diverse skillsets and roles to make successful team
 - Introduction to GitHub for collaboration, version control, project management, and content management
 - Understand how every person fits into the bigger picture of software development
 - Increase transparency through collaboration best practices
-- Use GitHub to document everything from markdown meeting notes to software documentation on GitHub Pages
-- Introduction to the benefits of GitHub Platform capabilities, including DevOps, CI, and CD
 
 ## Delivery Methods
 
@@ -32,7 +30,7 @@ It's no secret that it takes diverse skillsets and roles to make successful team
 
 ## Syllabus
 
-This hands-on engagement covers a broad range of technical and collaboration practices. Activities range from configuring integrations with the GitHub Platform to mapping real-life workflows. Though the technical experience of learners may vary, the activities introduce the software development lifecycle on GitHub from a non-developer perspective.  This training introduces learners to the work done on GitHub by developers and non-developers alike.
+This hands-on engagement covers a broad range of technical and collaboration practices. Activities range from managing a project on GitHub to effectively collaborating. Though the technical experience of learners may vary, the activities introduce the software development lifecycle on GitHub from a non-developer perspective. This training introduces learners to the work done on GitHub by developers and non-developers alike.
 
 - How work gets done on GitHub
   - Core concepts of version control
@@ -42,27 +40,16 @@ This hands-on engagement covers a broad range of technical and collaboration pra
   - Translate idealogical models to real world workflows
 - Repository ownership
   - Administrative settings and protected branches
-- CI, CD, and software lifecycle on GitHub
-  - CircleCI, Heroku, and GitHub's open platform
-  - Heroku review apps
-  - Working with forks
-  - Interacting with integrations
-- Documentation on GitHub
-  - Why documentation?
-  - Creating documentation
-  - Documentation on GitHub Pages
 
 ## Learning Outcomes
 
 After completing this training, learners will be able to:
 
+- Apply the GitHub Flow
 - Collaborate on Git and GitHub
-- Leverage integrations and automation
 - Understand how work gets done on GitHub
-- Create documentation on GitHub Pages
 
 ## Prerequisites
 
 - GitHub.com account created
-- CircleCI and Heroku accounts created
 - Access to a browser (**other than Internet Explorer**)


### PR DESCRIPTION
the [non-developer training for github](https://github.com/services/github-for-non-developers-training) references some things that aren't covered in [the slides](https://docs.google.com/presentation/d/15Npphuo5LVsvenMCIwJfYY841LVt9pCqQngncPOUyXc/edit#slide=id.g5449cee635_0_19) which have been removed. specifically:

1. references to third party systems like heroku and circle
2. references to CI/CD systems in general (covered in actions training)
3. references to creating and managing documentation in github

regarding `#3`, github pages is only used as a demo and it isn't explained well enough in the content to give the learners any meaningful info. maybe a deeper explanation of pages can replace the other topics that were removed, but that hasn't been discussed, so removal is the best option for now.