### PR TITLE
Revert "Declare offering delivery method and unit."

### DIFF
--- a/_offerings/bundle-ghas-getting-started.md
+++ b/_offerings/bundle-ghas-getting-started.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Getting Started
-delivery:
-  method: Bundled delivery, see bundle description.
-  unit: Bundle
 description: Supports you in "Getting Started" with GitHub Advanced Security (GHAS) and helps accelerate adoption in the critical first few weeks of deployment.
 parameterized_name: bundle-ghas-getting-started
 ---

--- a/_offerings/offering-actions-training.md
+++ b/_offerings/offering-actions-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Actions Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: This training will enable your teams to start leveraging GitHub Actions in their own projects across a multitude of use cases.
 parameterized_name: actions-training
 ---
@@ -33,7 +30,7 @@ GitHub Actions allow you to automate your workflows. This training will enable y
 
 ### Remote
 
-- Unit of Delivery: Class
+- Unit of Delivery: class
 - Participants: maximum 16 students
 
 ## Syllabus

--- a/_offerings/offering-admin-training-(github-enterprise-cloud).md
+++ b/_offerings/offering-admin-training-(github-enterprise-cloud).md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Admin Training (GitHub Enterprise Cloud)
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Prepare your GitHub Enterprise Cloud Administrators to maintain a healthy GitHub environment that supports the needs of your development team.
 parameterized_name: admin-training-github-enterprise-cloud
 ---

--- a/_offerings/offering-admin-training-(github-enterprise-server).md
+++ b/_offerings/offering-admin-training-(github-enterprise-server).md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Admin Training (GitHub Enterprise Server)
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Prepare your GitHub Enterprise Server Administrators to maintain a healthy, scalable GitHub environment that supports the needs of your development team.
 parameterized_name: admin-training-github-enterprise-server
 ---

--- a/_offerings/offering-api-training.md
+++ b/_offerings/offering-api-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub API Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: GitHub’s extensive API allows you to extend the platform to accommodate most modern workflows and easily get the data you need.
 parameterized_name: api-training
 ---

--- a/_offerings/offering-codeql-query-customizations.md
+++ b/_offerings/offering-codeql-query-customizations.md
@@ -1,10 +1,7 @@
 ---
 layout: page
 title: CodeQL Query Customizations
-delivery:
-  method: "`40` hours of enablement and workshops."
-  unit: Workshop
-description: Commission GitHub to customize the existing CodeQL queries to provide better results for your organization.
+description: Commision GitHub to customize the existing CodeQL queries to provide better results for your organization.
 parameterized_name: codeql-query-customizations
 ---
 

--- a/_offerings/offering-codeql-query-development.md
+++ b/_offerings/offering-codeql-query-development.md
@@ -1,10 +1,7 @@
 ---
 layout: page
 title: CodeQL Query Development
-delivery:
-  method: "`40` hours of enablement and workshops."
-  unit: Workshop
-description: Commission GitHub to develop CodeQL queries based on your unique business needs.
+description: Commision GitHub to develop CodeQL queries based on your unique business needs.
 parameterized_name: codeql-query-development
 ---
 

--- a/_offerings/offering-codeql-query-writing-tailored-workshop.md
+++ b/_offerings/offering-codeql-query-writing-tailored-workshop.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: CodeQL Query Writing Tailored Workshop
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Workshop
 description: This engagement creates a tailored 2 hour training course for using CodeQL to find a security vulnerbility or pattern of your choice.
 parameterized_name: codeql-query-writing-tailored-workshop
 ---

--- a/_offerings/offering-codeql-query-writing-training.md
+++ b/_offerings/offering-codeql-query-writing-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: CodeQL Query Writing Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Learn how to write CodeQL to find new security vulnerabilities or customize the existing rules through our extensive catalog of 2 hour training courses.
 parameterized_name: codeql-query-writing-training
 ---

--- a/_offerings/offering-copilot-for-business-fundamentals.md
+++ b/_offerings/offering-copilot-for-business-fundamentals.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Copilot for Business Fundamentals Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: GitHub Copilot is the world’s first at-scale AI developer tool. Sitting within the editor as a simple extension, GitHub Copilot draws context from a developer’s code to suggest new lines, entire functions, tests, and even complex algorithms.
 parameterized_name: copilot-for-business-fundamentals-training
 ---
@@ -40,7 +37,7 @@ Adopting GitHub Copilot can help companies improve their development processes, 
 
 ### Remote
 
-- Unit of Delivery: Class
+- Unit of Delivery: class
 - Participants: maximum 16 students
 
 ### Syllabus

--- a/_offerings/offering-ghas-developer-training.md
+++ b/_offerings/offering-ghas-developer-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Developer Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Allows you to have a "developer-first" approach to Application Security, recognizing that developers have a critical role to play in securing your applications.
 parameterized_name: ghas-developer-training
 ---

--- a/_offerings/offering-ghas-pilot-team-implementation.md
+++ b/_offerings/offering-ghas-pilot-team-implementation.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Pilot Team Implementation
-delivery:
-  method: "`6` hours maximum sync time."
-  unit: Workshop
 description: In this engagement we will work with a pilot or lighthouse team to help them enable GitHub Advanced Security for one or more key repositories.
 parameterized_name: ghas-pilot-team-implementation
 ---

--- a/_offerings/offering-ghas-rollout-deployment-training.md
+++ b/_offerings/offering-ghas-rollout-deployment-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Rollout and Deployment Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Provides support during the planning phases by providing best practices, recommended rollout strategies and identifying common pitfalls and issues.
 parameterized_name: ghas-rollout-deployment-training
 ---

--- a/_offerings/offering-ghas-security-advisory-services.md
+++ b/_offerings/offering-ghas-security-advisory-services.md
@@ -2,7 +2,7 @@
 layout: page
 title: GitHub Advanced Security - Security Advisory Services
 delivery:
-  method: "A minimum commitment of 4 hours per week; committed hours may be more based on contract duration."
+  method: "A minimum committed hours of 4 hours per week; committed hours may be more based on contract duration."
   unit: Days
 description: Identify your organization’s top priorities for improving your Secure Software Development Lifecycle with GitHub Advanced Security.
 parameterized_name: ghas-security-advisory-services

--- a/_offerings/offering-ghas-security-advisory-services.md
+++ b/_offerings/offering-ghas-security-advisory-services.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Security Advisory Services
-delivery:
-  method: "A minimum committed hours of 4 hours per week; committed hours may be more based on contract duration."
-  unit: Days
 description: Identify your organization’s top priorities for improving your Secure Software Development Lifecycle with GitHub Advanced Security.
 parameterized_name: ghas-security-advisory-services
 ---

--- a/_offerings/offering-ghas-security-results-review.md
+++ b/_offerings/offering-ghas-security-results-review.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Results Review
-delivery:
-  method: "`6` hours maximum sync time"
-  unit: Workshop
 description: Allows you to have a “developer-first” approach to Application Security, recognizing that developers have a critical role to play in securing your applications.
 parameterized_name: ghas-security-results-review
 ---

--- a/_offerings/offering-ghas-security-team-training.md
+++ b/_offerings/offering-ghas-security-team-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Advanced Security - Security Team Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Supports those who are responsible for reviewing, monitoring and driving remediation of security results across an enterprise.
 parameterized_name: ghas-security-team-training
 ---

--- a/_offerings/offering-github-for-developers-training.md
+++ b/_offerings/offering-github-for-developers-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub for Developers Training
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Give your developers confidence with Git and GitHub with hands-on, practical training from GitHub Expert Services.
 parameterized_name: github-for-developers-training
 ---

--- a/_offerings/offering-github-for-non-developers-training.md
+++ b/_offerings/offering-github-for-non-developers-training.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub for Non-Developers
-delivery:
-  method: "`3` hours per day over 2 days."
-  unit: Class
 description: Opening GitHub to a broad audience in your organization, gives your developers access to the expertise and diverse ways of thinking that represent your entire user population.
 parameterized_name: github-for-non-developers-training
 ---

--- a/_offerings/offering-implementation-(github-enterprise-cloud).md
+++ b/_offerings/offering-implementation-(github-enterprise-cloud).md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: Implementation (GitHub Enterprise Cloud)
-delivery:
-  method: "`6` hours maximum sync time"
-  unit: Class
 description: Equip your team with the knowledge they need to configure and manage your GitHub Enterprise Cloud account.
 parameterized_name: implementation-github-enterprise-cloud
 ---

--- a/_offerings/offering-implementation-(github-enterprise-server).md
+++ b/_offerings/offering-implementation-(github-enterprise-server).md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: Implementation (GitHub Enterprise Server)
-delivery:
-  method: "`6` hours maximum sync time"
-  unit: Class
 description: Equip your team with the knowledge they need to configure and manage your GitHub Enterprise Server account.
 parameterized_name: implementation-github-enterprise-server
 ---

--- a/_offerings/offering-migrations-emu.md
+++ b/_offerings/offering-migrations-emu.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: Migrations to GitHub Enterprise (GitHub Enterprise Cloud to GitHub Enterprise Cloud EMU)
-delivery:
-  method: "`40` hours of enablement and workshops."
-  unit: Workshop
 description: Ensure your GitHub Enterprise Cloud data is migrated to your GitHub Enterprise Cloud plus Enterprise Managed Users (EMU) platform account accurately and efficiently.
 parameterized_name: migrations-emu
 ---

--- a/_offerings/offering-migrations.md
+++ b/_offerings/offering-migrations.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: Migrations to GitHub Enterprise (Standard)
-delivery:
-  method: "`40` hours of enablement and workshops."
-  unit: Workshop
 description: Ensure your Version Control System (VCS) data is migrated to your GitHub Enterprise platform account accurately and efficiently.
 parameterized_name: migrations
 ---

--- a/_offerings/offering-technical-advisory-services.md
+++ b/_offerings/offering-technical-advisory-services.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: GitHub Technical Advisory Services
-delivery:
-  method: "A minimum committed hours of 4 hours per week; committed hours may be more based on contract duration."
-  unit: Days
 description: Identify your organization's top priorities for improving software delivery and enabling a digital transformation.
 parameterized_name: technical-advisory-services
 ---

--- a/_offerings/offering-technical-advisory-services.md
+++ b/_offerings/offering-technical-advisory-services.md
@@ -2,7 +2,7 @@
 layout: page
 title: GitHub Technical Advisory Services
 delivery:
-  method: "A minimum commitment of 4 hours per week; committed hours may be more based on contract duration."
+  method: "A minimum committed hours of 4 hours per week; committed hours may be more based on contract duration."
   unit: Days
 description: Identify your organization's top priorities for improving software delivery and enabling a digital transformation.
 parameterized_name: technical-advisory-services

--- a/_offerings/offering-workflow-consultation.md
+++ b/_offerings/offering-workflow-consultation.md
@@ -1,9 +1,6 @@
 ---
 layout: page
 title: Workflow Consultation
-delivery:
-  method: "`6` hours maximum sync time."
-  unit: Session
 description: Equip your team with the knowledge they need to evaluate, implement, document, and design a workflow solution optimized for your branching and release management strategy.
 parameterized_name: workflow-consultation
 ---

--- a/feed.json
+++ b/feed.json
@@ -14,8 +14,7 @@ permalink: feed.json
       "lead": {{ post.description | jsonify }},
       "content": {{ post.content | jsonify }},
       "parameterized_name": {{ post.parameterized_name | jsonify }},
-      "date_published": "{{ post.date | date_to_xmlschema }}",
-      "delivery": "{{ post.delivery | jsonify }}",
+      "date_published": "{{ post.date | date_to_xmlschema }}"
     }
     {% unless forloop.last %},{% endunless %}{% endfor %}
   ]


### PR DESCRIPTION
Reverts ps-resources/es-offerings-site-feed#17

Rolling back these changes as https://github.com/services#services-catalog or e.g. https://github.com/services/actions-training seem broken.