### PR TITLE
Add Tags and Categories

### DIFF
--- a/_offerings/bundle-ghas-getting-started.md
+++ b/_offerings/bundle-ghas-getting-started.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Getting Started
 description: Supports you in "Getting Started" with GitHub Advanced Security (GHAS) and helps accelerate adoption in the critical first few weeks of deployment.
 parameterized_name: bundle-ghas-getting-started
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/bundle-ghas-getting-started.md
+++ b/_offerings/bundle-ghas-getting-started.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Getting Started
 description: Supports you in "Getting Started" with GitHub Advanced Security (GHAS) and helps accelerate adoption in the critical first few weeks of deployment.
 parameterized_name: bundle-ghas-getting-started
-tag: TODO
+tag: Onboard
 category: Security
 ---
 

--- a/_offerings/offering-actions-training.md
+++ b/_offerings/offering-actions-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Actions Training
 description: This training will enable your teams to start leveraging GitHub Actions in their own projects across a multitude of use cases.
 parameterized_name: actions-training
+tag: Optimize
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-admin-training-(github-enterprise-cloud).md
+++ b/_offerings/offering-admin-training-(github-enterprise-cloud).md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Admin Training (GitHub Enterprise Cloud)
 description: Prepare your GitHub Enterprise Cloud Administrators to maintain a healthy GitHub environment that supports the needs of your development team.
 parameterized_name: admin-training-github-enterprise-cloud
+tag: Onboard
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-admin-training-(github-enterprise-server).md
+++ b/_offerings/offering-admin-training-(github-enterprise-server).md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Admin Training (GitHub Enterprise Server)
 description: Prepare your GitHub Enterprise Server Administrators to maintain a healthy, scalable GitHub environment that supports the needs of your development team.
 parameterized_name: admin-training-github-enterprise-server
+tag: Onboard
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-api-training.md
+++ b/_offerings/offering-api-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub API Training
 description: GitHub’s extensive API allows you to extend the platform to accommodate most modern workflows and easily get the data you need.
 parameterized_name: api-training
+tag: Optimize
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-codeql-query-customizations.md
+++ b/_offerings/offering-codeql-query-customizations.md
@@ -3,6 +3,8 @@ layout: page
 title: CodeQL Query Customizations
 description: Commision GitHub to customize the existing CodeQL queries to provide better results for your organization.
 parameterized_name: codeql-query-customizations
+tag: TODO
+category: Security
 ---
 
 ### Overview

--- a/_offerings/offering-codeql-query-customizations.md
+++ b/_offerings/offering-codeql-query-customizations.md
@@ -3,7 +3,7 @@ layout: page
 title: CodeQL Query Customizations
 description: Commision GitHub to customize the existing CodeQL queries to provide better results for your organization.
 parameterized_name: codeql-query-customizations
-tag: TODO
+tag: Optimize
 category: Security
 ---
 

--- a/_offerings/offering-codeql-query-development.md
+++ b/_offerings/offering-codeql-query-development.md
@@ -3,6 +3,8 @@ layout: page
 title: CodeQL Query Development
 description: Commision GitHub to develop CodeQL queries based on your unique business needs.
 parameterized_name: codeql-query-development
+tag: TODO
+category: Security
 ---
 
 ### Overview

--- a/_offerings/offering-codeql-query-development.md
+++ b/_offerings/offering-codeql-query-development.md
@@ -3,7 +3,7 @@ layout: page
 title: CodeQL Query Development
 description: Commision GitHub to develop CodeQL queries based on your unique business needs.
 parameterized_name: codeql-query-development
-tag: TODO
+tag: Optimize
 category: Security
 ---
 

--- a/_offerings/offering-codeql-query-writing-tailored-workshop.md
+++ b/_offerings/offering-codeql-query-writing-tailored-workshop.md
@@ -3,7 +3,7 @@ layout: page
 title: CodeQL Query Writing Tailored Workshop
 description: This engagement creates a tailored 2 hour training course for using CodeQL to find a security vulnerbility or pattern of your choice.
 parameterized_name: codeql-query-writing-tailored-workshop
-tag: TODO
+tag: Optimize
 category: Security
 ---
 

--- a/_offerings/offering-codeql-query-writing-tailored-workshop.md
+++ b/_offerings/offering-codeql-query-writing-tailored-workshop.md
@@ -3,6 +3,8 @@ layout: page
 title: CodeQL Query Writing Tailored Workshop
 description: This engagement creates a tailored 2 hour training course for using CodeQL to find a security vulnerbility or pattern of your choice.
 parameterized_name: codeql-query-writing-tailored-workshop
+tag: TODO
+category: Security
 ---
 
 ### Overview

--- a/_offerings/offering-codeql-query-writing-training.md
+++ b/_offerings/offering-codeql-query-writing-training.md
@@ -3,7 +3,7 @@ layout: page
 title: CodeQL Query Writing Training
 description: Learn how to write CodeQL to find new security vulnerabilities or customize the existing rules through our extensive catalog of 2 hour training courses.
 parameterized_name: codeql-query-writing-training
-tag: TODO
+tag: Optimize
 category: Security
 ---
 

--- a/_offerings/offering-codeql-query-writing-training.md
+++ b/_offerings/offering-codeql-query-writing-training.md
@@ -3,6 +3,8 @@ layout: page
 title: CodeQL Query Writing Training
 description: Learn how to write CodeQL to find new security vulnerabilities or customize the existing rules through our extensive catalog of 2 hour training courses.
 parameterized_name: codeql-query-writing-training
+tag: TODO
+category: Security
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-administration-security-intermediate.md
+++ b/_offerings/offering-copilot-administration-security-intermediate.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Copilot for Business Administration and Security
 description: GitHub Copilot is the world’s first at-scale AI developer tool. Sitting within the editor as a simple extension, GitHub Copilot draws context from a developer’s code to suggest new lines, entire functions, tests, and even complex algorithms.
 parameterized_name: github-copilot-for-business-administration-security-intermediate
+tag: Optimize
+category: AI
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-for-business-adoption-at-scale.md
+++ b/_offerings/offering-copilot-for-business-adoption-at-scale.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Copilot for Business Adoption at Scale 
 description: GitHub Copilot is the world’s first at-scale AI developer tool. Sitting within the editor as a simple extension, GitHub Copilot draws context from a developer’s code to suggest new lines, entire functions, tests, and even complex algorithms.
 parameterized_name: github-copilot-for-business-adoption-at-scale
+tag: Adopt
+category: AI
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-for-business-fundamentals.md
+++ b/_offerings/offering-copilot-for-business-fundamentals.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Copilot for Business Fundamentals Training
 description: GitHub Copilot is the world’s first at-scale AI developer tool. Sitting within the editor as a simple extension, GitHub Copilot draws context from a developer’s code to suggest new lines, entire functions, tests, and even complex algorithms.
 parameterized_name: copilot-for-business-fundamentals-training
+tag: Adopt
+category: AI
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-for-developers-intermediate.md
+++ b/_offerings/offering-copilot-for-developers-intermediate.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Copilot for Developers Intermediate
 description: GitHub Copilot is the world’s first at-scale AI developer tool. Sitting within the editor as a simple extension, GitHub Copilot draws context from a developer’s code to suggest new lines, entire functions, tests, and even complex algorithms.
 parameterized_name: github-copilot-for-developers-intermediate
+tag: Optimize
+category: AI
 ---
 
 ### Overview

--- a/_offerings/offering-ghas-developer-training.md
+++ b/_offerings/offering-ghas-developer-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Developer Training
 description: Allows you to have a "developer-first" approach to Application Security, recognizing that developers have a critical role to play in securing your applications.
 parameterized_name: ghas-developer-training
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/offering-ghas-developer-training.md
+++ b/_offerings/offering-ghas-developer-training.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Developer Training
 description: Allows you to have a "developer-first" approach to Application Security, recognizing that developers have a critical role to play in securing your applications.
 parameterized_name: ghas-developer-training
-tag: TODO
+tag: Onboard
 category: Security
 ---
 

--- a/_offerings/offering-ghas-pilot-team-implementation.md
+++ b/_offerings/offering-ghas-pilot-team-implementation.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Pilot Team Implementation
 description: In this engagement we will work with a pilot or lighthouse team to help them enable GitHub Advanced Security for one or more key repositories.
 parameterized_name: ghas-pilot-team-implementation
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/offering-ghas-pilot-team-implementation.md
+++ b/_offerings/offering-ghas-pilot-team-implementation.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Pilot Team Implementation
 description: In this engagement we will work with a pilot or lighthouse team to help them enable GitHub Advanced Security for one or more key repositories.
 parameterized_name: ghas-pilot-team-implementation
-tag: TODO
+tag: Adopt
 category: Security
 ---
 

--- a/_offerings/offering-ghas-rollout-deployment-training.md
+++ b/_offerings/offering-ghas-rollout-deployment-training.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Rollout and Deployment Training
 description: Provides support during the planning phases by providing best practices, recommended rollout strategies and identifying common pitfalls and issues.
 parameterized_name: ghas-rollout-deployment-training
-tag: TODO
+tag: Onboard
 category: Security
 ---
 

--- a/_offerings/offering-ghas-rollout-deployment-training.md
+++ b/_offerings/offering-ghas-rollout-deployment-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Rollout and Deployment Training
 description: Provides support during the planning phases by providing best practices, recommended rollout strategies and identifying common pitfalls and issues.
 parameterized_name: ghas-rollout-deployment-training
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/offering-ghas-security-advisory-services.md
+++ b/_offerings/offering-ghas-security-advisory-services.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Security Advisory Services
 description: Identify your organization’s top priorities for improving your Secure Software Development Lifecycle with GitHub Advanced Security.
 parameterized_name: ghas-security-advisory-services
-tag: TODO
+tag: Optimize
 category: Security
 ---
 

--- a/_offerings/offering-ghas-security-advisory-services.md
+++ b/_offerings/offering-ghas-security-advisory-services.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Security Advisory Services
 description: Identify your organization’s top priorities for improving your Secure Software Development Lifecycle with GitHub Advanced Security.
 parameterized_name: ghas-security-advisory-services
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/offering-ghas-security-results-review.md
+++ b/_offerings/offering-ghas-security-results-review.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Results Review
 description: Allows you to have a “developer-first” approach to Application Security, recognizing that developers have a critical role to play in securing your applications.
 parameterized_name: ghas-security-results-review
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/offering-ghas-security-results-review.md
+++ b/_offerings/offering-ghas-security-results-review.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Results Review
 description: Allows you to have a “developer-first” approach to Application Security, recognizing that developers have a critical role to play in securing your applications.
 parameterized_name: ghas-security-results-review
-tag: TODO
+tag: Adopt
 category: Security
 ---
 

--- a/_offerings/offering-ghas-security-team-training.md
+++ b/_offerings/offering-ghas-security-team-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Advanced Security - Security Team Training
 description: Supports those who are responsible for reviewing, monitoring and driving remediation of security results across an enterprise.
 parameterized_name: ghas-security-team-training
+tag: TODO
+category: Security
 ---
 
 ## Overview

--- a/_offerings/offering-ghas-security-team-training.md
+++ b/_offerings/offering-ghas-security-team-training.md
@@ -3,7 +3,7 @@ layout: page
 title: GitHub Advanced Security - Security Team Training
 description: Supports those who are responsible for reviewing, monitoring and driving remediation of security results across an enterprise.
 parameterized_name: ghas-security-team-training
-tag: TODO
+tag: Onboard
 category: Security
 ---
 

--- a/_offerings/offering-github-for-developers-training.md
+++ b/_offerings/offering-github-for-developers-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub for Developers Training
 description: Give your developers confidence with Git and GitHub with hands-on, practical training from GitHub Expert Services.
 parameterized_name: github-for-developers-training
+tag: Adopt
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-github-for-non-developers-training.md
+++ b/_offerings/offering-github-for-non-developers-training.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub for Non-Developers
 description: Opening GitHub to a broad audience in your organization, gives your developers access to the expertise and diverse ways of thinking that represent your entire user population.
 parameterized_name: github-for-non-developers-training
+tag: Adopt
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-implementation-(github-enterprise-cloud).md
+++ b/_offerings/offering-implementation-(github-enterprise-cloud).md
@@ -3,6 +3,8 @@ layout: page
 title: Implementation (GitHub Enterprise Cloud)
 description: Equip your team with the knowledge they need to configure and manage your GitHub Enterprise Cloud account.
 parameterized_name: implementation-github-enterprise-cloud
+tag: Onboard
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-implementation-(github-enterprise-server).md
+++ b/_offerings/offering-implementation-(github-enterprise-server).md
@@ -3,6 +3,8 @@ layout: page
 title: Implementation (GitHub Enterprise Server)
 description: Equip your team with the knowledge they need to configure and manage your GitHub Enterprise Server account.
 parameterized_name: implementation-github-enterprise-server
+tag: Onboard
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-migrations-emu.md
+++ b/_offerings/offering-migrations-emu.md
@@ -3,6 +3,8 @@ layout: page
 title: Migrations to GitHub Enterprise (GitHub Enterprise Cloud to GitHub Enterprise Cloud EMU)
 description: Ensure your GitHub Enterprise Cloud data is migrated to your GitHub Enterprise Cloud plus Enterprise Managed Users (EMU) platform account accurately and efficiently.
 parameterized_name: migrations-emu
+tag: Onboard
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-migrations.md
+++ b/_offerings/offering-migrations.md
@@ -3,6 +3,8 @@ layout: page
 title: Migrations to GitHub Enterprise (Standard)
 description: Ensure your Version Control System (VCS) data is migrated to your GitHub Enterprise platform account accurately and efficiently.
 parameterized_name: migrations
+tag: Onboard
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-technical-advisory-services.md
+++ b/_offerings/offering-technical-advisory-services.md
@@ -3,6 +3,8 @@ layout: page
 title: GitHub Technical Advisory Services
 description: Identify your organization's top priorities for improving software delivery and enabling a digital transformation.
 parameterized_name: technical-advisory-services
+tag: Optimize
+category: Platform
 ---
 
 ## Overview

--- a/_offerings/offering-workflow-consultation.md
+++ b/_offerings/offering-workflow-consultation.md
@@ -3,6 +3,8 @@ layout: page
 title: Workflow Consultation
 description: Equip your team with the knowledge they need to evaluate, implement, document, and design a workflow solution optimized for your branching and release management strategy.
 parameterized_name: workflow-consultation
+tag: Optimize
+category: Platform
 ---
 
 ## Overview

--- a/feed.json
+++ b/feed.json
@@ -15,7 +15,9 @@ permalink: feed.json
       "content": {{ post.content | jsonify }},
       "parameterized_name": {{ post.parameterized_name | jsonify }},
       "delivery": {{ post.delivery | jsonify }},
-      "date_published": "{{ post.date | date_to_xmlschema }}"
+      "date_published": "{{ post.date | date_to_xmlschema }}",
+      "tag": {{ post.tag | jsonify }},
+      "category": {{ post.category | jsonify }}
     }
     {% unless forloop.last %},{% endunless %}{% endfor %}
   ]


### PR DESCRIPTION
As part of this [work stream](https://github.com/github/customer-success-engineering/issues/2815) we'd like to add two new properties to each service catalog entry: `tag` and `category`. The tag will be either `Onboard`, `Adopt`, or `Optimize` and the category will be either `Platform`, `Security`, or `AI`. These additional properties will allow us to use this JSON feed for a new UI we are building in the Support Portal to enable customers to filter and search for services based on these properties.

### Changes
- Adds `tag` and `category` to each post in the offerings folder.
- Adds these two new fields to the feed.json template.

### Testing
- Unfortunately I was having some trouble getting the test script or the server script to run successfully in a new Codespace on main 😞 so I wasn't able to test this locally. Is there a good way to test these changes?

