### PR TITLE
Revert "Remove Github Technical Advisory Services Offering"

### DIFF
--- a/_offerings/offering-technical-advisory-services.md
+++ b/_offerings/offering-technical-advisory-services.md
@@ -1,0 +1,53 @@
+---
+layout: page
+title: GitHub Technical Advisory Services
+description: Identify your organization's top priorities for improving software delivery and enabling a digital transformation.
+parameterized_name: technical-advisory-services
+tag: Optimize
+category: Platform
+---
+
+## Overview
+
+GitHub's Technical Advisory Services pairs you up with an expert from GitHub's team to identify your organization's top priorities for improving software delivery and enabling a digital transformation. With these priorities in mind you and this advisor will build out a roadmap to accomplish these priorities, check in weekly to track progress, and have asynchronous communication channels available to work together to accomplish your goals.
+
+## Target Audience
+
+- CTO
+- CIO
+- GitHub Admins
+
+## Key Features and Benefits
+
+- Develop digital transformation with an eye towards identified priorities
+- Identify a named resource to work with on top priorities to save you valuable time
+- Use Slack, a shared GitHub repo for collaboration, and an identified set of success criteria to works towards identifying goals
+- Receive consulting and advising on paths to success with a GitHub Expert
+
+## Delivery Methods
+
+Delivered as a combination of remote and onsite meetings for a total of 40 days in a year with 2 onsite visits.
+
+## Syllabus
+
+In the beginning weeks of the year-long engagement your team will work closely with a GitHub Solution Architect to establish the success criteria and software delivery abilities that your organization needs to accomplish your goals. Then, we will meet weekly to ensure we are accomplishing these goals. Your Solution Architect will work with you to advise you on GitHub best practices and help you build a strong foundation on GitHub's offerings.
+
+- Report on progress against the success criteria and scoping for upcoming sessions
+- Prioritize areas for improvement
+- Develop a plan to accomplish top tasks
+- Weekly check-ins to track progress against initiatives
+- Identify your organization's abilities and areas for improvement
+- Coordination between GitHub team members to drive completion of initiatives
+
+## Business Outcomes
+
+After this engagement, your team will be able to:
+
+- Identify and accomplish your organization's top priorities
+- Infrastructure to meet the needs of your growing use of GitHub
+- Expert level knowledge of administration of GitHub
+
+## Prerequisites
+
+- An identified resource to work closely with the GitHub Solution Architect throughout the year
+- Availability of leadership team to work with the Solution Architect closely to establish success criteria


### PR DESCRIPTION
Reverts ps-resources/es-offerings-site-feed#29 due to https://github.com/github/customer-success-engineering/issues/3192