### PR TITLE
Add `is_included_in_premium_plus` metadata to offerings

### DIFF
--- a/_offerings/offering-actions-training.md
+++ b/_offerings/offering-actions-training.md
@@ -5,6 +5,7 @@ description: This training will enable your teams to start leveraging GitHub Act
 parameterized_name: actions-training
 tag: Optimize
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-admin-training-(github-enterprise-cloud).md
+++ b/_offerings/offering-admin-training-(github-enterprise-cloud).md
@@ -5,6 +5,7 @@ description: Prepare your GitHub Enterprise Cloud Administrators to maintain a h
 parameterized_name: admin-training-github-enterprise-cloud
 tag: Onboard
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-admin-training-(github-enterprise-server).md
+++ b/_offerings/offering-admin-training-(github-enterprise-server).md
@@ -5,6 +5,7 @@ description: Prepare your GitHub Enterprise Server Administrators to maintain a 
 parameterized_name: admin-training-github-enterprise-server
 tag: Onboard
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-api-training.md
+++ b/_offerings/offering-api-training.md
@@ -5,6 +5,7 @@ description: GitHub’s extensive API allows you to extend the platform to accom
 parameterized_name: api-training
 tag: Optimize
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-copilot-administration-security-intermediate.md
+++ b/_offerings/offering-copilot-administration-security-intermediate.md
@@ -5,6 +5,7 @@ description: GitHub Copilot is the world’s first at-scale AI developer tool. S
 parameterized_name: github-copilot-for-business-administration-security-intermediate
 tag: Optimize
 category: AI
+is_included_in_premium_plus: true
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-for-business-adoption-at-scale.md
+++ b/_offerings/offering-copilot-for-business-adoption-at-scale.md
@@ -5,6 +5,7 @@ description: GitHub Copilot is the world’s first at-scale AI developer tool. S
 parameterized_name: github-copilot-for-business-adoption-at-scale
 tag: Adopt
 category: AI
+is_included_in_premium_plus: true
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-for-business-fundamentals.md
+++ b/_offerings/offering-copilot-for-business-fundamentals.md
@@ -5,6 +5,7 @@ description: GitHub Copilot is the world’s first at-scale AI developer tool. S
 parameterized_name: copilot-for-business-fundamentals-training
 tag: Adopt
 category: AI
+is_included_in_premium_plus: true
 ---
 
 ### Overview

--- a/_offerings/offering-copilot-for-developers-intermediate.md
+++ b/_offerings/offering-copilot-for-developers-intermediate.md
@@ -5,6 +5,7 @@ description: GitHub Copilot is the world’s first at-scale AI developer tool. S
 parameterized_name: github-copilot-for-developers-intermediate
 tag: Optimize
 category: AI
+is_included_in_premium_plus: true
 ---
 
 ### Overview

--- a/_offerings/offering-github-for-developers-training.md
+++ b/_offerings/offering-github-for-developers-training.md
@@ -5,6 +5,7 @@ description: Give your developers confidence with Git and GitHub with hands-on, 
 parameterized_name: github-for-developers-training
 tag: Adopt
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-github-for-non-developers-training.md
+++ b/_offerings/offering-github-for-non-developers-training.md
@@ -5,6 +5,7 @@ description: Opening GitHub to a broad audience in your organization, gives your
 parameterized_name: github-for-non-developers-training
 tag: Adopt
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-implementation-(github-enterprise-cloud).md
+++ b/_offerings/offering-implementation-(github-enterprise-cloud).md
@@ -5,6 +5,7 @@ description: Equip your team with the knowledge they need to configure and manag
 parameterized_name: implementation-github-enterprise-cloud
 tag: Onboard
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/_offerings/offering-implementation-(github-enterprise-server).md
+++ b/_offerings/offering-implementation-(github-enterprise-server).md
@@ -5,6 +5,7 @@ description: Equip your team with the knowledge they need to configure and manag
 parameterized_name: implementation-github-enterprise-server
 tag: Onboard
 category: Platform
+is_included_in_premium_plus: true
 ---
 
 ## Overview

--- a/feed.json
+++ b/feed.json
@@ -17,7 +17,8 @@ permalink: feed.json
       "delivery": {{ post.delivery | jsonify }},
       "date_published": "{{ post.date | date_to_xmlschema }}",
       "tag": {{ post.tag | jsonify }},
-      "category": {{ post.category | jsonify }}
+      "category": {{ post.category | jsonify }},
+      "is_included_in_premium_plus": {{ post.is_included_in_premium_plus | jsonify }}
     }
     {% unless forloop.last %},{% endunless %}{% endfor %}
   ]


### PR DESCRIPTION
Relates to https://github.com/github/customer-success-engineering/issues/3885.

Adds an `is_included_in_premium_plus` optional boolean field to several of the expert services offerings. This field will be used by HelpHub on the [services-catalog](https://support.github.com/success/services-catalog) page to display a "Premium Plus" badge on the relevant offerings.