### PR TITLE
Update offering-implementation-(github-enterprise-server).md

### DIFF
--- a/_offerings/offering-implementation-(github-enterprise-server).md
+++ b/_offerings/offering-implementation-(github-enterprise-server).md
@@ -5,7 +5,7 @@ description: Equip your team with the knowledge they need to configure and manag
 parameterized_name: implementation-github-enterprise-server
 tag: Onboard
 category: Platform
-is_included_in_premium_plus: true
+is_included_in_premium_plus: false
 ---
 
 ## Overview


### PR DESCRIPTION
No longer include "Implementation (server)" as included in Premium Plus +

cc https://github.com/github/customer-success-engineering/issues/4156