### PR TITLE
Updated agendas to match training content and other minor edits

### DIFF
--- a/_offerings/offering-admin-training-(github-enterprise-cloud).md
+++ b/_offerings/offering-admin-training-(github-enterprise-cloud).md
@@ -21,7 +21,6 @@ GitHub Application Admins
 - Properly configure your GitHub Enterprise Cloud account to meet your organization's needs
 - Improve the developer experience by selecting appropriate organization settings
 - Identify the recommended options and configurations to reach your desired outcomes
-- Enable protected branches, issues, GitHub Pages and more
 - Locate metrics from your GitHub Enterprise organization
 - Audit critical activities performed on your GitHub Enterprise Cloud account
 
@@ -73,5 +72,5 @@ After completing this training, admins will be able to:
 
 - Provision the GitHub Enterprise Cloud organization you will be using
 - All users with computers, accounts, and access for GitHub.com
-- Ensure at least one attendee has owner or administrator access
-- Designate one owner or administrator to share their screen during activities
+- Ensure at least one attendee will have administrator access (enterprise, organization and repository)
+- Designate one or more administrators to share their screen during activities

--- a/_offerings/offering-admin-training-(github-enterprise-server).md
+++ b/_offerings/offering-admin-training-(github-enterprise-server).md
@@ -23,11 +23,8 @@ Prepare your GitHub Enterprise Server Administrators to maintain a healthy, scal
 - Implement a more secure and dependable instance that is prepared to scale with your organization
 - Improve the developer experience by selecting appropriate options
 - Identify the options and configurations to reach your desired outcomes
-- Enable protected branches, issues, GitHub Pages and more
-- Demonstrate daily and advanced user behavior on GitHub
 - Locate metrics within your GitHub Enterprise instance
 - Audit critical activities performed on your GitHub Enterprise Server instance
-- Implement high availability and backup instances based on your organization's needs
 
 ## Delivery Methods
 
@@ -38,43 +35,29 @@ Prepare your GitHub Enterprise Server Administrators to maintain a healthy, scal
 
 ## Syllabus
 
-Participants can expect a combination of classroom learning and hands-on activities that build experience and confidence using the GitHub Enterprise Cloud platform.
+Participants can expect a combination of classroom learning and hands-on activities that build experience and confidence using the GitHub Enterprise Server platform.
 
-- GitHub Enterprise setup
-  - Accessing the instance
-  - SSH access & command line utilities
-  - Hostname and subdomain isolation
-  - Authentication and privacy
-- Working on GitHub
-  - Create branches and pull requests
-  - Configure protected branches
-  - Configure required status checks
-  - GitHub Pages
-- Maintaining a healthy instance
-  - Monitoring
-  - Maintenance mode
-  - Version upgrades
-  - High availability replica instance
-  - Backup utilities
-- Site Administration
-  - Admin center (advanced settings)
-  - Audit account activities
-  - Repository settings
-- User administration
-  - Account impersonation
-  - Manage dormant users
-  - Organizations and teams
-- The GitHub API
-  - API Overview
-  - REST API and GraphQL
-  - GitHub platform-samples
-  - Integrate tests and results using the Status API
-  - Deploy with GitHub
-  - Webhooks
-  - Scripts and automation
-- Advanced user behavior and administration
-  - Unhealthy repositories
-  - Changing history with Git
+### Day 1
+- GitHub Enterprise overview
+  - Platforms
+  - Permission flow
+  - Enterprise administration
+  - Settings walkthrough
+- GitHub organizations
+  - Overview
+  - Administration and policies
+  - Settings walkthrough
+
+### Day 2
+- GitHub repositories
+  - Overview
+  - Repository administration
+  - Branch protection and CODEOWNERS file
+  - Settings walkthrough
+- Additional topics
+  - API overview and authentication methods
+  - GitHub Actions
+  - GitHub Marketplace
 
 ## Learning & Business Outcomes
 
@@ -91,6 +74,6 @@ After completing this training, admins will be able to:
 ## Prerequisites
 
 - A staging instance for use during the training
-- All users with computers, accounts, and access for GitHub.com
-- Ensure that all attendees will have administrator access
-- Designate one administrator to share their screen during activities
+- All users with computers, accounts, and access for the staging instance
+- Ensure at least one attendee will have administrator access (enterprise, organization and repository)
+- Designate one or more administrators to share their screen during activities


### PR DESCRIPTION
This pull request updates the training documentation for GitHub Enterprise Cloud and Server offerings to clarify prerequisites, streamline learning outcomes, and modernize the syllabus for the server training.

Closes https://github.com/ps-resources/es-offerings-assets/issues/304 and https://github.com/ps-resources/es-offerings-assets/issues/306