### PR TITLE
Removed unnecessary GitHub Pages bullet point

### DIFF
--- a/_offerings/offering-implementation-(github-enterprise-server).md
+++ b/_offerings/offering-implementation-(github-enterprise-server).md
@@ -43,7 +43,6 @@ In this engagement, a GitHub professional will guide you through the process of 
 - Selecting security settings to fit your business environment
 - Configuring high availability and backups
 - Reviewing essential best practices for users and teams
-- Leveraging GitHub Enterprise Pages
 - Leveraging repository and organization webhooks for integrations
 
 _Note: The syllabus is reviewed periodically and may change to ensure updated content are presented._


### PR DESCRIPTION
This pull request makes a minor update to the implementation offering documentation by removing the mention of leveraging GitHub Enterprise Pages from the syllabus section. This helps keep the syllabus focused and up-to-date.

Closes https://github.com/ps-resources/es-offerings-assets/issues/301