### PR TITLE
Add GitHub Custom Learning offering details

### DIFF
--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -46,9 +46,9 @@ This offering helps customers:
 
 - Accelerate, goal-aligned adoption of GitHub products and features
 - Provide clear, role-based learning paths for identified personas
-- Relevant, customized learning content tailored to the customer environment 
-- Scalable education model that integrates with existing learning platforms 
-- A repeatable foundation for sustained enablement and maturity growth 
+- Provide relevant, customized learning content tailored to the customer environment
+- Establish a scalable education model that integrates with existing learning platforms
+- Create a repeatable foundation for sustained enablement and maturity growth 
   
 ## Audience
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -44,8 +44,8 @@ Through guided working sessions and applied enablement support, customers establ
 
 This offering helps customers:
 
-- Accelerate, goal‑aligned adoption of GitHub products and features 
-- Provide clear, role‑based learning paths for identified personas 
+- Accelerate, goal-aligned adoption of GitHub products and features
+- Provide clear, role-based learning paths for identified personas
 - Relevant, customized learning content tailored to the customer environment 
 - Scalable education model that integrates with existing learning platforms 
 - A repeatable foundation for sustained enablement and maturity growth 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -56,7 +56,7 @@ This offering helps customers:
 
 - Technical Leads or Product Owners 
 - Enablement/Learning Leads 
-- Champions or Early Adoptors 
+- Champions or Early Adopters 
 
 ## Delivery details
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -76,9 +76,9 @@ Before this training, the customer needs to have in place:
 
 ### Key stakeholders and ownership
 
-- Identified learning or enablement lead to act as primary point of contact 
-- Named decision makers for scope, priorities, and delivery approvals 
-- Agreement on required vs. optional participation for target audiences 
+- Identified learning or enablement lead to act as primary point of contact
+- Named decision makers for scope, priorities, and delivery approvals
+- Agreement on required vs. optional participation for target audiences
 
 ### Audience and personas
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -87,6 +87,6 @@ Before this training, the customer needs to have in place:
 
 ### Learning requirements
 
-- Clarity on whether training or enablement activities are mandatory or optional 
-- Success criteria for completion (e.g., completion tracking, certifications, adoption milestones) 
+- Clarity on whether training or enablement activities are mandatory or optional
+- Success criteria for completion (e.g., completion tracking, certifications, adoption milestones)
 - Understanding of learning platforms, existing learning subscriptions, and communication mechanisms.

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -18,11 +18,11 @@ Through guided working sessions and applied enablement support, customers establ
 
 ### Learning Path Design and Strategic Enablement Planning
 
- - A structured, goal‑driven learning curriculum aligned to their business and engineering priorities
- - Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams)
- - Sequenced content that progresses from foundational concepts to applied, real‑world workflows
- - Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes
- - A repeatable learning framework that supports sustained enablement at scale
+- A structured, goal‑driven learning curriculum aligned to their business and engineering priorities
+- Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams)
+- Sequenced content that progresses from foundational concepts to applied, real‑world workflows
+- Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes
+- A repeatable learning framework that supports sustained enablement at scale
 
 ### Content Customization and Development
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -34,10 +34,10 @@ Through guided working sessions and applied enablement support, customers establ
 
 ### Learning Platform Integration and Testing
 
-- Guidance integrating curated learning content into their existing learning platforms or delivery tools 
-- Validation that learning materials are accessible, structured, and aligned to the intended learning journey 
-- Testing to ensure content supports learner navigation, engagement, and completion 
-- A scalable approach to delivering GitHub education consistently across teams 
+- Guidance integrating curated learning content into their existing learning platforms or delivery tools
+- Validation that learning materials are accessible, structured, and aligned to the intended learning journey
+- Testing to ensure content supports learner navigation, engagement, and completion
+- A scalable approach to delivering GitHub education consistently across teams
 - Confidence that learning experiences are ready for broader rollout and ongoing use
 
 ## Customer benefits

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -71,7 +71,7 @@ Before this training, the customer needs to have in place:
 
 ### Business context and goals
 
-- Defined business and engineering goals the enablement effort should support 
+- Defined business and engineering goals the enablement effort should support
 - Target GitHub products and features in scope (e.g., Copilot, Actions, Admin/Governance, etc)
 
 ### Key stakeholders and ownership

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -54,9 +54,9 @@ This offering helps customers:
 
 **Required**:
 
-- Technical Leads or Product Owners 
-- Enablement/Learning Leads 
-- Champions or Early Adopters 
+- Technical Leads or Product Owners
+- Enablement/Learning Leads
+- Champions or Early Adopters
 
 ## Delivery details
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -26,11 +26,11 @@ Through guided working sessions and applied enablement support, customers establ
 
 ### Content Customization and Development
 
-- Curated GitHub learning content tailored to their products, features, and use cases 
+- Curated GitHub learning content tailored to their products, features, and use cases
 - Customized materials that reflect the customer’s environment, workflows, and priorities
-- Practical examples and scenarios grounded in real customer development and operational contexts 
-- Targeted learning assets that reinforce adoption of GitHub best practices 
-- Content designed to drive relevance, engagement, and immediate application 
+- Practical examples and scenarios grounded in real customer development and operational contexts
+- Targeted learning assets that reinforce adoption of GitHub best practices
+- Content designed to drive relevance, engagement, and immediate application
 
 ### Learning Platform Integration and Testing
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -12,7 +12,7 @@ is_included_in_premium_plus: true
 
 The Custom Learning offering is a tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals. 
 In this Custom Learning engagement, GitHub Customer Enablement experts partner with customers to design and deliver targeted learning experiences aligned to GitHub products, features, and business objectives. The engagement focuses on understanding customer goals, audiences, and current state, then curating and developing learning content that supports effective adoption across teams. 
-Through guided working sessions and applied enablement support, customers establish structured, role‑based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes. 
+Through guided working sessions and applied enablement support, customers establish structured, role-based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes.
 
 ## Topics
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -82,8 +82,8 @@ Before this training, the customer needs to have in place:
 
 ### Audience and personas
 
-- Identified primary personas to enable (e.g., developers, administrators, platform teams) 
-- Approximate audience size and role distribution 
+- Identified primary personas to enable (e.g., developers, administrators, platform teams)
+- Approximate audience size and role distribution
 
 ### Learning requirements
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -1,7 +1,7 @@
 ---
 layout: page
 title: GitHub Custom Learning
-description:  This tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals.
+description: A tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals.
 parameterized_name: custom-learning
 tag: Optimize
 category: AI
@@ -16,7 +16,7 @@ Through guided working sessions and applied enablement support, customers establ
 
 ## Topics
 
-### Learning Path Design and Strategic Enablement Planning ###
+### Learning Path Design and Strategic Enablement Planning
 
 - A structured, goal‑driven learning curriculum aligned to their business and engineering priorities 
 - Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams) 
@@ -24,7 +24,7 @@ Through guided working sessions and applied enablement support, customers establ
 - Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes 
 - A repeatable learning framework that supports sustained enablement at scale  
 
-### Content Customization and Development ###
+### Content Customization and Development
 
 - Curated GitHub learning content tailored to their products, features, and use cases 
 - Customized materials that reflect the customer’s environment, workflows, and priorities
@@ -32,7 +32,7 @@ Through guided working sessions and applied enablement support, customers establ
 - Targeted learning assets that reinforce adoption of GitHub best practices 
 - Content designed to drive relevance, engagement, and immediate application 
 
-### Learning Platform Integration and Testing ###
+### Learning Platform Integration and Testing
 
 - Guidance integrating curated learning content into their existing learning platforms or delivery tools 
 - Validation that learning materials are accessible, structured, and aligned to the intended learning journey 
@@ -56,7 +56,7 @@ This offering helps customers:
 
 - Technical Leads or Product Owners 
 - Enablement/Learning Leads 
-- Champions or Early Adoptors 
+- Champions or Early Adopters 
 
 ## Delivery details
 
@@ -71,23 +71,23 @@ This offering helps customers:
 
 Before this training, the customer needs to have in place:
 
-### Business context and goals ###
+### Business context and goals
 
 - Defined business and engineering goals the enablement effort should support 
 - Target GitHub products and features in scope (e.g., Copilot, Actions, Admin/Governance, etc)
 
-### Key stakeholders and ownership ###
+### Key stakeholders and ownership
 
 - Identified learning or enablement lead to act as primary point of contact 
 - Named decision makers for scope, priorities, and delivery approvals 
 - Agreement on required vs. optional participation for target audiences 
 
-### Audience and personas ###
+### Audience and personas
 
 - Identified primary personas to enable (e.g., developers, administrators, platform teams) 
 - Approximate audience size and role distribution 
 
-### Learning requirements ###
+### Learning requirements
 
 - Clarity on whether training or enablement activities are mandatory or optional 
 - Success criteria for completion (e.g., completion tracking, certifications, adoption milestones) 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -49,7 +49,7 @@ This offering helps customers:
 - Provide relevant, customized learning content tailored to the customer environment
 - Establish a scalable education model that integrates with existing learning platforms
 - Create a repeatable foundation for sustained enablement and maturity growth
-  
+
 ## Audience
 
 **Required**:

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -10,9 +10,9 @@ is_included_in_premium_plus: true
 
 ## Overview
 
- The Custom Learning offering is a tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals.
- In this Custom Learning engagement, GitHub Customer Enablement experts partner with customers to design and deliver targeted learning experiences aligned to GitHub products, features, and business objectives. The engagement focuses on understanding customer goals, audiences, and current state, then curating and developing learning content that supports effective adoption across teams.
- Through guided working sessions and applied enablement support, customers establish structured, role‑based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes.
+The Custom Learning offering is a tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals.
+In this Custom Learning engagement, GitHub Customer Enablement experts partner with customers to design and deliver targeted learning experiences aligned to GitHub products, features, and business objectives. The engagement focuses on understanding customer goals, audiences, and current state, then curating and developing learning content that supports effective adoption across teams.
+Through guided working sessions and applied enablement support, customers establish structured, role‑based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes.
 
 ## Topics
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -18,9 +18,9 @@ Through guided working sessions and applied enablement support, customers establ
 
 ### Learning Path Design and Strategic Enablement Planning
 
-- A structured, goal‑driven learning curriculum aligned to their business and engineering priorities 
-- Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams) 
-- Sequenced content that progresses from foundational concepts to applied, real‑world workflows 
+- A structured, goal-driven learning curriculum aligned to their business and engineering priorities
+- Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams)
+- Sequenced content that progresses from foundational concepts to applied, real-world workflows
 - Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes 
 - A repeatable learning framework that supports sustained enablement at scale  
 

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -1,0 +1,94 @@
+---
+layout: page
+title: GitHub Custom Learning
+description:  This tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals.
+parameterized_name: custom-learning
+tag: Optimize
+category: AI
+is_included_in_premium_plus: true
+---
+
+## Overview
+
+The Custom Learning offering is a tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals. 
+In this Custom Learning engagement, GitHub Customer Enablement experts partner with customers to design and deliver targeted learning experiences aligned to GitHub products, features, and business objectives. The engagement focuses on understanding customer goals, audiences, and current state, then curating and developing learning content that supports effective adoption across teams. 
+Through guided working sessions and applied enablement support, customers establish structured, role‑based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes. 
+
+## Topics
+
+### Learning Path Design and Strategic Enablement Planning ###
+
+- A structured, goal‑driven learning curriculum aligned to their business and engineering priorities 
+- Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams) 
+- Sequenced content that progresses from foundational concepts to applied, real‑world workflows 
+- Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes 
+- A repeatable learning framework that supports sustained enablement at scale  
+
+### Content Customization and Development ###
+
+- Curated GitHub learning content tailored to their products, features, and use cases 
+- Customized materials that reflect the customer’s environment, workflows, and priorities
+- Practical examples and scenarios grounded in real customer development and operational contexts 
+- Targeted learning assets that reinforce adoption of GitHub best practices 
+- Content designed to drive relevance, engagement, and immediate application 
+
+### Learning Platform Integration and Testing ###
+
+- Guidance integrating curated learning content into their existing learning platforms or delivery tools 
+- Validation that learning materials are accessible, structured, and aligned to the intended learning journey 
+- Testing to ensure content supports learner navigation, engagement, and completion 
+- A scalable approach to delivering GitHub education consistently across teams 
+- Confidence that learning experiences are ready for broader rollout and ongoing use
+
+## Customer benefits
+
+This offering helps customers:
+
+- Accelerate, goal‑aligned adoption of GitHub products and features 
+- Provide clear, role‑based learning paths for identified personas 
+- Relevant, customized learning content tailored to the customer environment 
+- Scalable education model that integrates with existing learning platforms 
+- A repeatable foundation for sustained enablement and maturity growth 
+  
+## Audience
+
+**Required**:
+
+- Technical Leads or Product Owners 
+- Enablement/Learning Leads 
+- Champions or Early Adoptors 
+
+## Delivery details
+
+- **Level:** 100-300+
+- **Offering type:** Custom Services
+- **Format:** Remote
+- **Class size:** Not applicable [working with sponsors]
+- **Schedule:** Not applicable [aligned to standard services advisory hours] 
+- **Customer pre-work:** Yes, details will be provided before the session starts.
+
+## Customer prerequisites
+
+Before this training, the customer needs to have in place:
+
+### Business context and goals ###
+
+- Defined business and engineering goals the enablement effort should support 
+- Target GitHub products and features in scope (e.g., Copilot, Actions, Admin/Governance, etc)
+
+### Key stakeholders and ownership ###
+
+- Identified learning or enablement lead to act as primary point of contact 
+- Named decision makers for scope, priorities, and delivery approvals 
+- Agreement on required vs. optional participation for target audiences 
+
+### Audience and personas ###
+
+- Identified primary personas to enable (e.g., developers, administrators, platform teams) 
+- Approximate audience size and role distribution 
+
+### Learning requirements ###
+
+- Clarity on whether training or enablement activities are mandatory or optional 
+- Success criteria for completion (e.g., completion tracking, certifications, adoption milestones) 
+- Understanding of learning platforms, existing learning subscriptions, and communication mechanisms.

--- a/_offerings/offering-custom-learning.md
+++ b/_offerings/offering-custom-learning.md
@@ -10,19 +10,19 @@ is_included_in_premium_plus: true
 
 ## Overview
 
-The Custom Learning offering is a tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals. 
-In this Custom Learning engagement, GitHub Customer Enablement experts partner with customers to design and deliver targeted learning experiences aligned to GitHub products, features, and business objectives. The engagement focuses on understanding customer goals, audiences, and current state, then curating and developing learning content that supports effective adoption across teams. 
-Through guided working sessions and applied enablement support, customers establish structured, role-based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes.
+ The Custom Learning offering is a tailored 100-hour engagement that enables customers to design and deliver targeted GitHub learning experiences aligned to their business and engineering goals.
+ In this Custom Learning engagement, GitHub Customer Enablement experts partner with customers to design and deliver targeted learning experiences aligned to GitHub products, features, and business objectives. The engagement focuses on understanding customer goals, audiences, and current state, then curating and developing learning content that supports effective adoption across teams.
+ Through guided working sessions and applied enablement support, customers establish structured, role‑based learning paths that reinforce best practices, operational workflows, and GitHub product capabilities—helping translate platform investments into sustained business and engineering outcomes.
 
 ## Topics
 
 ### Learning Path Design and Strategic Enablement Planning
 
-- A structured, goal-driven learning curriculum aligned to their business and engineering priorities
-- Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams)
-- Sequenced content that progresses from foundational concepts to applied, real-world workflows
-- Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes 
-- A repeatable learning framework that supports sustained enablement at scale  
+ - A structured, goal‑driven learning curriculum aligned to their business and engineering priorities
+ - Clearly defined learning paths mapped to roles (e.g., developers, admins, platform teams)
+ - Sequenced content that progresses from foundational concepts to applied, real‑world workflows
+ - Alignment between GitHub product capabilities and the customer’s desired adoption and maturity outcomes
+ - A repeatable learning framework that supports sustained enablement at scale
 
 ### Content Customization and Development
 
@@ -48,7 +48,7 @@ This offering helps customers:
 - Provide clear, role-based learning paths for identified personas
 - Provide relevant, customized learning content tailored to the customer environment
 - Establish a scalable education model that integrates with existing learning platforms
-- Create a repeatable foundation for sustained enablement and maturity growth 
+- Create a repeatable foundation for sustained enablement and maturity growth
   
 ## Audience
 
@@ -56,15 +56,13 @@ This offering helps customers:
 
 - Technical Leads or Product Owners 
 - Enablement/Learning Leads 
-- Champions or Early Adopters 
+- Champions or Early Adoptors 
 
 ## Delivery details
 
-- **Level:** 100-300+
-- **Offering type:** Custom Services
+- **Level:** Fundamentals [100] to Advanced [300]
+- **Offering type:** Service
 - **Format:** Remote
-- **Class size:** Not applicable [working with sponsors]
-- **Schedule:** Not applicable [aligned to standard services advisory hours] 
 - **Customer pre-work:** Yes, details will be provided before the session starts.
 
 ## Customer prerequisites


### PR DESCRIPTION
Added a new offering for GitHub Custom Learning, detailing the engagement structure, topics covered, customer benefits, audience requirements, delivery details, and prerequisites for participation.